### PR TITLE
Use deep equality check for diffing attributes

### DIFF
--- a/lib/is.js
+++ b/lib/is.js
@@ -1,15 +1,5 @@
 module.exports = {
-  equal: function (a, b) {
-    if (a === b) return true;
-    if (a == null && b == null) return true;
-    if (a == null || b == null) return false;
-    if (Object.keys(a).length != Object.keys(b).length) return false;
-    for(var key in a) {
-      // Only compare one level deep
-      if (a[key] !== b[key]) return false;
-    }
-    return true;
-  },
+  equal: require('deep-equal'),
 
   array: function (value) {
     return Array.isArray(value);

--- a/lib/op.js
+++ b/lib/op.js
@@ -29,7 +29,7 @@ var lib = {
       if (!is.object(a)) a = {};
       if (!is.object(b)) b = {};
       var attributes = Object.keys(a).concat(Object.keys(b)).reduce(function (attributes, key) {
-        if (a[key] !== b[key]) {
+        if (!is.equal(a[key], b[key])) {
           attributes[key] = b[key] === undefined ? null : b[key];
         }
         return attributes;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/ottypes/rich-text",
   "main": "index.js",
   "dependencies": {
+    "deep-equal": "~0.2.1",
     "fast-diff": "git://github.com/tangentialism/fast-diff#master"
   },
   "devDependencies": {

--- a/test/fuzzer.js
+++ b/test/fuzzer.js
@@ -4,8 +4,8 @@ var richType = require('../lib/type');
 var Delta = richType.Delta;
 
 var FORMATS = {
-  color: ['red', 'orange', 'yellow', 'green', 'blue', 'purple', null],
-  font: ['serif', 'sans-serif', 'monospace', null],
+  color: ['red', 'orange', 'yellow', 'green', 'blue', 'purple', { complex: 'value' }, null],
+  font: ['serif', 'sans-serif', 'monospace', [1, 2, 3], null],
   bold: [true, null],
   italic: [true, null]
 };

--- a/test/is.js
+++ b/test/is.js
@@ -9,9 +9,15 @@ describe('is', function () {
       expect(is.equal(obj, obj)).to.equal(true);
     });
 
-    it('deep equal objects', function () {
+    it('one level deep equal objects', function () {
       var obj1 = { a: 1, b: true, c: 'test' };
       var obj2 = { a: 1, c: 'test', b: true };
+      expect(is.equal(obj1, obj2, 1)).to.equal(true);
+    });
+
+    it('two level deep equal objects', function() {
+      var obj1 = { a: 1, b: { c: true } };
+      var obj2 = { a: 1, b: { c: true } };
       expect(is.equal(obj1, obj2)).to.equal(true);
     });
 
@@ -28,7 +34,7 @@ describe('is', function () {
     });
 
     it('null and undefined', function () {
-      expect(is.equal(null, undefined)).to.equal(true);
+      expect(is.equal(null, undefined)).to.equal(false);
     });
 
     it('existing with nonexisting', function () {


### PR DESCRIPTION
Replace custom `is.equal` implementation with that of the `deep-equal` library, which is a popular pick on npm.
